### PR TITLE
Fix BodyComponent generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
  - BodyComponent should follow Forge2D game debug mode
+ - Fix generics for BodyComponent
  
 ## [0.6.0-rc2]
  - Align with Flame 1.0.0-rc5

--- a/lib/body_component.dart
+++ b/lib/body_component.dart
@@ -12,8 +12,9 @@ import 'viewport.dart';
 
 /// Since a pure BodyComponent doesn't have anything drawn on top of it,
 /// it is a good idea to turn on debudMode for it so that the bodies can be seen
-abstract class BodyComponent extends BaseComponent
-    with HasGameRef<Forge2DGame> {
+
+abstract class BodyComponent<T extends Forge2DGame> extends BaseComponent
+    with HasGameRef<T> {
   static const maxPolygonVertices = 8;
   static const defaultColor = const Color.fromARGB(255, 255, 255, 255);
 


### PR DESCRIPTION
Since `hasGameRef` can't use anything else than the pure `Forge2DGame`.